### PR TITLE
Add kwargs to process_tokens

### DIFF
--- a/aesthetic_clip.py
+++ b/aesthetic_clip.py
@@ -199,7 +199,7 @@ class AestheticCLIP:
             self.image_embs.requires_grad_(False)
 
     def __call__(self, remade_batch_tokens, multipliers, **kwargs):
-        z = self.process_tokens(remade_batch_tokens, multipliers)
+        z = self.process_tokens(remade_batch_tokens, multipliers, **kwargs)
 
         if not self.skip and self.aesthetic_steps != 0 and self.aesthetic_lr != 0 and self.aesthetic_weight != 0 and self.image_embs_name is not None:
             tokenizer = shared.sd_model.cond_stage_model.tokenizer

--- a/aesthetic_clip.py
+++ b/aesthetic_clip.py
@@ -198,7 +198,7 @@ class AestheticCLIP:
             self.image_embs /= self.image_embs.norm(dim=-1, keepdim=True)
             self.image_embs.requires_grad_(False)
 
-    def __call__(self, remade_batch_tokens, multipliers):
+    def __call__(self, remade_batch_tokens, multipliers, **kwargs):
         z = self.process_tokens(remade_batch_tokens, multipliers)
 
         if not self.skip and self.aesthetic_steps != 0 and self.aesthetic_lr != 0 and self.aesthetic_weight != 0 and self.image_embs_name is not None:


### PR DESCRIPTION
This PR is related to https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/3469

- add `kwargs`  to process_tokens in sd_hijack.py
- hooked AestheticCLIP to receive it and pass to downstream.

This PR itself does not change any behavior, but help in adding other changes.